### PR TITLE
Arp per interface

### DIFF
--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -325,12 +325,19 @@ static TickType_t xLastGratuitousARPTime = 0U;
                                     /* The request is a Gratuitous ARP message.
                                      * Refresh the entry if it already exists. */
                                     /* Determine the ARP cache status for the requested IP address. */
-                                    if( eARPGetCacheEntry( &( ulSenderProtocolAddress ), &( xHardwareAddress ), &( pxCachedEndPoint ), pxNetworkBuffer->pxEndPoint->pxNetworkInterface ) == eARPCacheHit )
+                                    if( eARPGetCacheEntry( &( ulSenderProtocolAddress ),
+                                                           &( xHardwareAddress ),
+                                                           &( pxCachedEndPoint ),
+                                                           pxNetworkBuffer->pxEndPoint->pxNetworkInterface )
+                                        == eARPCacheHit )
                                     {
                                         /* Check if the endpoint matches with the one present in the ARP cache */
                                         if( pxCachedEndPoint == pxTargetEndPoint )
                                         {
-                                            vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress, pxTargetEndPoint, pxNetworkBuffer->pxInterface );
+                                            vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ),
+                                                                   ulSenderProtocolAddress,
+                                                                   pxTargetEndPoint,
+                                                                   pxNetworkBuffer->pxInterface );
                                         }
                                     }
                                 }

--- a/source/FreeRTOS_ARP.c
+++ b/source/FreeRTOS_ARP.c
@@ -97,18 +97,21 @@
  */
     static eARPLookupResult_t prvCacheLookup( uint32_t ulAddressToLookup,
                                               MACAddress_t * const pxMACAddress,
-                                              NetworkEndPoint_t ** ppxEndPoint );
+                                              NetworkEndPoint_t ** ppxEndPoint,
+                                              struct xNetworkInterface * pxInterface );
 
     static eARPLookupResult_t eARPGetCacheEntryGateWay( uint32_t * pulIPAddress,
                                                         MACAddress_t * const pxMACAddress,
-                                                        struct xNetworkEndPoint ** ppxEndPoint );
+                                                        struct xNetworkEndPoint ** ppxEndPoint,
+                                                        struct xNetworkInterface * pxInterface );
 
 #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
 static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
                                      const uint32_t ulIPAddress,
                                      struct xNetworkEndPoint * pxEndPoint,
-                                     CacheLocation_t * pxLocation );
+                                     CacheLocation_t * pxLocation,
+                                     struct xNetworkInterface * pxInterface );
 
 /*-----------------------------------------------------------*/
 
@@ -322,12 +325,12 @@ static TickType_t xLastGratuitousARPTime = 0U;
                                     /* The request is a Gratuitous ARP message.
                                      * Refresh the entry if it already exists. */
                                     /* Determine the ARP cache status for the requested IP address. */
-                                    if( eARPGetCacheEntry( &( ulSenderProtocolAddress ), &( xHardwareAddress ), &( pxCachedEndPoint ) ) == eARPCacheHit )
+                                    if( eARPGetCacheEntry( &( ulSenderProtocolAddress ), &( xHardwareAddress ), &( pxCachedEndPoint ), pxNetworkBuffer->pxInterface ) == eARPCacheHit )
                                     {
                                         /* Check if the endpoint matches with the one present in the ARP cache */
                                         if( pxCachedEndPoint == pxTargetEndPoint )
                                         {
-                                            vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress, pxTargetEndPoint );
+                                            vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress, pxTargetEndPoint, pxNetworkBuffer->pxInterface );
                                         }
                                     }
                                 }
@@ -385,7 +388,7 @@ static TickType_t xLastGratuitousARPTime = 0U;
         /* The request is for the address of this node.  Add the
          * entry into the ARP cache, or refresh the entry if it
          * already exists. */
-        vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress, pxTargetEndPoint );
+        vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress, pxTargetEndPoint, pxTargetEndPoint->pxNetworkInterface );
 
         /* Generate a reply payload in the same buffer. */
         pxARPHeader->usOperation = ( uint16_t ) ipARP_REPLY;
@@ -431,10 +434,13 @@ static TickType_t xLastGratuitousARPTime = 0U;
 
         /* If the packet is meant for this device or if the entry already exists. */
         if( ( ulTargetProtocolAddress == pxTargetEndPoint->ipv4_settings.ulIPAddress ) ||
-            ( xIsIPInARPCache( ulSenderProtocolAddress ) == pdTRUE ) )
+            ( xIsIPInARPCache( ulSenderProtocolAddress, pxTargetEndPoint->pxNetworkInterface ) == pdTRUE ) )
         {
             iptracePROCESSING_RECEIVED_ARP_REPLY( ulTargetProtocolAddress );
-            vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ), ulSenderProtocolAddress, pxTargetEndPoint );
+            vARPRefreshCacheEntry( &( pxARPHeader->xSenderHardwareAddress ),
+                                   ulSenderProtocolAddress,
+                                   pxTargetEndPoint,
+                                   pxTargetEndPoint->pxNetworkInterface );
         }
 
         if( ( pxARPWaitingNetworkBuffer != NULL ) &&
@@ -482,13 +488,21 @@ static TickType_t xLastGratuitousARPTime = 0U;
  *
  * @return When the IP-address is found: pdTRUE, else pdFALSE.
  */
-BaseType_t xIsIPInARPCache( uint32_t ulAddressToLookup )
+BaseType_t xIsIPInARPCache( uint32_t ulAddressToLookup, struct xNetworkInterface * pxInterface )
 {
     BaseType_t x, xReturn = pdFALSE;
+
+
+    configASSERT( pxInterface != NULL );
 
     /* Loop through each entry in the ARP cache. */
     for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
     {
+        if( xARPCache[ x ].pxInterface != pxInterface )
+        {
+            continue;
+        }
+
         /* Does this row in the ARP cache table hold an entry for the IP address
          * being queried? */
         if( xARPCache[ x ].ulIPAddress == ulAddressToLookup )
@@ -536,7 +550,7 @@ BaseType_t xCheckRequiresARPResolution( const NetworkBufferDescriptor_t * pxNetw
                    {
                        /* If the IP is on the same subnet and we do not have an ARP entry already,
                         * then we should send out ARP for finding the MAC address. */
-                       if( xIsIPInARPCache( pxIPHeader->ulSourceIPAddress ) == pdFALSE )
+                       if( xIsIPInARPCache( pxIPHeader->ulSourceIPAddress, pxNetworkBuffer->pxInterface ) == pdFALSE )
                        {
                            FreeRTOS_OutputARPRequest( pxIPHeader->ulSourceIPAddress );
 
@@ -620,16 +634,22 @@ BaseType_t xCheckRequiresARPResolution( const NetworkBufferDescriptor_t * pxNetw
  *                          be removed.
  * @return When the entry was found and remove: the IP-address, otherwise zero.
  */
-    uint32_t ulARPRemoveCacheEntryByMac( const MACAddress_t * pxMACAddress )
+    uint32_t ulARPRemoveCacheEntryByMac( const MACAddress_t * pxMACAddress, struct xNetworkInterface * pxInterface)
     {
         BaseType_t x;
         uint32_t lResult = 0;
 
         configASSERT( pxMACAddress != NULL );
+        configASSERT( pxInterface != NULL);
 
         /* For each entry in the ARP cache table. */
         for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
         {
+            if( xARPCache[ x ].pxInterface != pxInterface )
+            {
+                continue;
+            }
+
             if( ( memcmp( xARPCache[ x ].xMACAddress.ucBytes, pxMACAddress->ucBytes, sizeof( pxMACAddress->ucBytes ) ) == 0 ) )
             {
                 lResult = xARPCache[ x ].ulIPAddress;
@@ -652,15 +672,23 @@ BaseType_t xCheckRequiresARPResolution( const NetworkBufferDescriptor_t * pxNetw
  * @param[in] ulIPAddress the IP address whose corresponding entry needs to be updated.
  */
 void vARPRefreshCacheEntryAge( const MACAddress_t * pxMACAddress,
-                               const uint32_t ulIPAddress )
+                               const uint32_t ulIPAddress,
+                               struct xNetworkInterface * pxInterface )
 {
     BaseType_t x;
+
+    configASSERT( pxInterface != NULL );
 
     if( pxMACAddress != NULL )
     {
         /* Loop through each entry in the ARP cache. */
         for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
         {
+            if( xARPCache[ x ].pxInterface != pxInterface )
+            {
+                continue;
+            }
+
             /* Does this line in the cache table hold an entry for the IP
              * address being queried? */
             if( xARPCache[ x ].ulIPAddress == ulIPAddress )
@@ -689,8 +717,11 @@ void vARPRefreshCacheEntryAge( const MACAddress_t * pxMACAddress,
  */
 void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
                             const uint32_t ulIPAddress,
-                            struct xNetworkEndPoint * pxEndPoint )
+                            struct xNetworkEndPoint * pxEndPoint,
+                            struct xNetworkInterface * pxInterface )
 {
+    configASSERT( pxInterface != NULL );
+
     #if ( ipconfigARP_STORES_REMOTE_ADDRESSES == 0 )
         /* Only process the IP address if it is on the local network. */
         BaseType_t xAddressIsLocal = ( FreeRTOS_FindEndPointOnNetMask( ulIPAddress, 2 ) != NULL ) ? 1 : 0; /* ARP remote address. */
@@ -712,7 +743,7 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
         CacheLocation_t xLocation;
         BaseType_t xReady;
 
-        xReady = prvFindCacheEntry( pxMACAddress, ulIPAddress, pxEndPoint, &( xLocation ) );
+        xReady = prvFindCacheEntry( pxMACAddress, ulIPAddress, pxEndPoint, &( xLocation ), pxInterface );
 
         if( xReady == pdFALSE )
         {
@@ -776,11 +807,14 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
 static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
                                      const uint32_t ulIPAddress,
                                      struct xNetworkEndPoint * pxEndPoint,
-                                     CacheLocation_t * pxLocation )
+                                     CacheLocation_t * pxLocation,
+                                     struct xNetworkInterface * pxInterface )
 {
     BaseType_t x = 0;
     uint8_t ucMinAgeFound = 0U;
     BaseType_t xReturn = pdFALSE;
+
+    configASSERT( pxInterface != NULL );
 
     #if ( ipconfigARP_STORES_REMOTE_ADDRESSES != 0 )
         BaseType_t xAddressIsLocal = ( FreeRTOS_FindEndPointOnNetMask( ulIPAddress, 2 ) != NULL ) ? 1 : 0; /* ARP remote address. */
@@ -797,6 +831,11 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
     for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
     {
         BaseType_t xMatchingMAC = pdFALSE;
+
+        if( xARPCache[ x ].pxInterface != pxInterface )
+        {
+            continue;
+        }
 
         if( pxMACAddress != NULL )
         {
@@ -954,7 +993,8 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
  */
     eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
                                           MACAddress_t * const pxMACAddress,
-                                          struct xNetworkEndPoint ** ppxEndPoint )
+                                          struct xNetworkEndPoint ** ppxEndPoint,
+                                          struct xNetworkInterface * pxInterface )
     {
         eARPLookupResult_t eReturn;
         uint32_t ulAddressToLookup;
@@ -963,6 +1003,7 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
         configASSERT( pxMACAddress != NULL );
         configASSERT( pulIPAddress != NULL );
         configASSERT( ppxEndPoint != NULL );
+        configASSERT( pxInterface != NULL );
 
         *( ppxEndPoint ) = NULL;
         ulAddressToLookup = *pulIPAddress;
@@ -1004,7 +1045,7 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
         }
         else
         {
-            eReturn = eARPGetCacheEntryGateWay( pulIPAddress, pxMACAddress, ppxEndPoint );
+            eReturn = eARPGetCacheEntryGateWay( pulIPAddress, pxMACAddress, ppxEndPoint, pxInterface );
         }
 
         return eReturn;
@@ -1021,12 +1062,15 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
  */
     static eARPLookupResult_t eARPGetCacheEntryGateWay( uint32_t * pulIPAddress,
                                                         MACAddress_t * const pxMACAddress,
-                                                        struct xNetworkEndPoint ** ppxEndPoint )
+                                                        struct xNetworkEndPoint ** ppxEndPoint,
+                                                        struct xNetworkInterface * pxInterface )
     {
         eARPLookupResult_t eReturn = eARPCacheMiss;
         uint32_t ulAddressToLookup = *( pulIPAddress );
         NetworkEndPoint_t * pxEndPoint;
         uint32_t ulOrginal = *pulIPAddress;
+
+        configASSERT( pxInterface != NULL );
 
         /* It is assumed that devices with the same netmask are on the same
          * LAN and don't need a gateway. */
@@ -1036,7 +1080,7 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
         {
             /* No matching end-point is found, look for a gateway. */
             #if ( ipconfigARP_STORES_REMOTE_ADDRESSES == 1 )
-                eReturn = prvCacheLookup( ulAddressToLookup, pxMACAddress, ppxEndPoint );
+                eReturn = prvCacheLookup( ulAddressToLookup, pxMACAddress, ppxEndPoint, pxInterface );
 
                 if( eReturn == eARPCacheHit )
                 {
@@ -1082,7 +1126,7 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
             }
             else
             {
-                eReturn = prvCacheLookup( ulAddressToLookup, pxMACAddress, ppxEndPoint );
+                eReturn = prvCacheLookup( ulAddressToLookup, pxMACAddress, ppxEndPoint, pxInterface );
 
                 if( ( eReturn != eARPCacheHit ) || ( ulOrginal != ulAddressToLookup ) )
                 {
@@ -1116,14 +1160,22 @@ static BaseType_t prvFindCacheEntry( const MACAddress_t * pxMACAddress,
  */
     static eARPLookupResult_t prvCacheLookup( uint32_t ulAddressToLookup,
                                               MACAddress_t * const pxMACAddress,
-                                              NetworkEndPoint_t ** ppxEndPoint )
+                                              NetworkEndPoint_t ** ppxEndPoint,
+                                              struct xNetworkInterface * pxInterface )
     {
         BaseType_t x;
         eARPLookupResult_t eReturn = eARPCacheMiss;
 
+        configASSERT( pxInterface != NULL );
+
         /* Loop through each entry in the ARP cache. */
         for( x = 0; x < ipconfigARP_CACHE_ENTRIES; x++ )
         {
+            if( xARPCache[ x ].pxInterface != pxInterface )
+            {
+                continue;
+            }
+
             /* Does this row in the ARP cache table hold an entry for the IP address
              * being queried? */
             if( xARPCache[ x ].ulIPAddress == ulAddressToLookup )
@@ -1348,7 +1400,8 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
  * @return Zero when successful.
  */
     BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
-                                   TickType_t uxTicksToWait )
+                                   TickType_t uxTicksToWait,
+                                   struct xNetworkInterface * pxInterface )
     {
         BaseType_t xResult = -pdFREERTOS_ERRNO_EADDRNOTAVAIL;
         TimeOut_t xTimeOut;
@@ -1361,7 +1414,7 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
         /* The IP-task is not supposed to call this function. */
         configASSERT( xIsCallingFromIPTask() == pdFALSE );
 
-        xLookupResult = eARPGetCacheEntry( &( ulIPAddressCopy ), &( xMACAddress ), &( pxEndPoint ) );
+        xLookupResult = eARPGetCacheEntry( &( ulIPAddressCopy ), &( xMACAddress ), &( pxEndPoint ), pxInterface );
 
         if( xLookupResult == eARPCacheMiss )
         {
@@ -1376,7 +1429,7 @@ void FreeRTOS_OutputARPRequest( uint32_t ulIPAddress )
 
                 vTaskDelay( uxSleepTime );
 
-                xLookupResult = eARPGetCacheEntry( &( ulIPAddressCopy ), &( xMACAddress ), &( pxEndPoint ) );
+                xLookupResult = eARPGetCacheEntry( &( ulIPAddressCopy ), &( xMACAddress ), &( pxEndPoint ), pxInterface );
 
                 if( ( xTaskCheckForTimeOut( &( xTimeOut ), &( uxTicksToWait ) ) == pdTRUE ) ||
                     ( xLookupResult != eARPCacheMiss ) )

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1950,7 +1950,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( const IPPacket_t * pxIPPacke
                         #if ( ipconfigUSE_IPv4 != 0 )
                             case ipIPv4_FRAME_TYPE:
                                 /* Refresh the age of this cache entry since a packet was received. */
-                                vARPRefreshCacheEntryAge( &( pxIPPacket->xEthernetHeader.xSourceAddress ), pxIPHeader->ulSourceIPAddress, pxNetworkBuffer->pxInterface );
+                                vARPRefreshCacheEntryAge( &( pxIPPacket->xEthernetHeader.xSourceAddress ), pxIPHeader->ulSourceIPAddress, pxNetworkBuffer->pxEndPoint->pxNetworkInterface );
                                 break;
                         #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 

--- a/source/FreeRTOS_IP.c
+++ b/source/FreeRTOS_IP.c
@@ -1950,7 +1950,7 @@ static eFrameProcessingResult_t prvProcessIPPacket( const IPPacket_t * pxIPPacke
                         #if ( ipconfigUSE_IPv4 != 0 )
                             case ipIPv4_FRAME_TYPE:
                                 /* Refresh the age of this cache entry since a packet was received. */
-                                vARPRefreshCacheEntryAge( &( pxIPPacket->xEthernetHeader.xSourceAddress ), pxIPHeader->ulSourceIPAddress );
+                                vARPRefreshCacheEntryAge( &( pxIPPacket->xEthernetHeader.xSourceAddress ), pxIPHeader->ulSourceIPAddress, pxNetworkBuffer->pxInterface );
                                 break;
                         #endif /* ( ipconfigUSE_IPv4 != 0 ) */
 
@@ -2129,7 +2129,7 @@ void vReturnEthernetFrame( NetworkBufferDescriptor_t * pxNetworkBuffer,
 
                         /* Try to find a MAC address corresponding to the destination IP
                          * address. */
-                        eResult = eARPGetCacheEntry( &ulDestinationIPAddress, &xMACAddress, &( pxNetworkBuffer->pxEndPoint ) );
+                        eResult = eARPGetCacheEntry( &ulDestinationIPAddress, &xMACAddress, &( pxNetworkBuffer->pxEndPoint ), pxNetworkBuffer->pxInterface );
 
                         if( eResult == eARPCacheHit )
                         {

--- a/source/FreeRTOS_TCP_Transmission_IPv4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPv4.c
@@ -236,7 +236,7 @@ void prvTCPReturnPacket_IPV4( FreeRTOS_Socket_t * pxSocket,
             ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
             eARPLookupResult_t eResult;
 
-            eResult = eARPGetCacheEntry( &ulDestinationIPAddress, &xMACAddress, &( pxNetworkBuffer->pxEndPoint ) );
+            eResult = eARPGetCacheEntry( &ulDestinationIPAddress, &xMACAddress, &( pxNetworkBuffer->pxEndPoint ), pxNetworkBuffer->pxInterface);
 
             if( eResult == eARPCacheHit )
             {
@@ -339,7 +339,7 @@ BaseType_t prvTCPPrepareConnect_IPV4( FreeRTOS_Socket_t * pxSocket )
 
     ulRemoteIP = FreeRTOS_htonl( pxSocket->u.xTCP.xRemoteIP.ulIP_IPv4 );
     /* Determine the ARP cache status for the requested IP address. */
-    eReturned = eARPGetCacheEntry( &( ulRemoteIP ), &( xEthAddress ), &( pxSocket->pxEndPoint ) );
+    eReturned = eARPGetCacheEntry( &( ulRemoteIP ), &( xEthAddress ), &( pxSocket->pxEndPoint ), pxSocket->pxEndPoint->pxNetworkInterface );
 
     switch( eReturned )
     {

--- a/source/FreeRTOS_TCP_Transmission_IPv4.c
+++ b/source/FreeRTOS_TCP_Transmission_IPv4.c
@@ -236,7 +236,7 @@ void prvTCPReturnPacket_IPV4( FreeRTOS_Socket_t * pxSocket,
             ulDestinationIPAddress = pxIPHeader->ulDestinationIPAddress;
             eARPLookupResult_t eResult;
 
-            eResult = eARPGetCacheEntry( &ulDestinationIPAddress, &xMACAddress, &( pxNetworkBuffer->pxEndPoint ), pxNetworkBuffer->pxInterface);
+            eResult = eARPGetCacheEntry( &ulDestinationIPAddress, &xMACAddress, &( pxNetworkBuffer->pxEndPoint ), pxSocket->pxEndPoint->pxNetworkInterface );
 
             if( eResult == eARPCacheHit )
             {

--- a/source/FreeRTOS_UDP_IPv4.c
+++ b/source/FreeRTOS_UDP_IPv4.c
@@ -251,7 +251,7 @@ void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetwor
             /* Add an entry to the ARP table with a null hardware address.
              * This allows the ARP timer to know that an ARP reply is
              * outstanding, and perform retransmissions if necessary. */
-            vARPRefreshCacheEntry( NULL, ulIPAddress, NULL, pxNetworkBuffer->pxInterface );
+            vARPRefreshCacheEntry( NULL, ulIPAddress, NULL, pxNetworkBuffer->pxEndPoint->pxNetworkInterface );
 
             /* Generate an ARP for the required IP address. */
             iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->xIPAddress.ulIP_IPv4 );
@@ -503,7 +503,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
                 if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ( uint16_t ) ipDNS_PORT )
                 {
                     vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress,
-                                           pxNetworkBuffer->pxEndPoint, pxNetworkBuffer->pxInterface );
+                                           pxNetworkBuffer->pxEndPoint, pxNetworkBuffer->pxEndPoint->pxNetworkInterface );
                     xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
                 }
                 else
@@ -534,7 +534,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
                     #endif
                     {
                         vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress,
-                                               pxNetworkBuffer->pxEndPoint, pxNetworkBuffer->pxInterface );
+                                               pxNetworkBuffer->pxEndPoint, pxNetworkBuffer->pxEndPoint->pxNetworkInterface );
                     }
 
                     xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );

--- a/source/FreeRTOS_UDP_IPv4.c
+++ b/source/FreeRTOS_UDP_IPv4.c
@@ -106,7 +106,7 @@ void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetwor
     }
 
     /* Determine the ARP cache status for the requested IP address. */
-    eReturned = eARPGetCacheEntry( &( ulIPAddress ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ), &( pxEndPoint ) );
+    eReturned = eARPGetCacheEntry( &( ulIPAddress ), &( pxUDPPacket->xEthernetHeader.xDestinationAddress ), &( pxEndPoint ), pxNetworkBuffer->pxInterface );
 
     if( pxNetworkBuffer->pxEndPoint == NULL )
     {
@@ -251,7 +251,7 @@ void vProcessGeneratedUDPPacket_IPv4( NetworkBufferDescriptor_t * const pxNetwor
             /* Add an entry to the ARP table with a null hardware address.
              * This allows the ARP timer to know that an ARP reply is
              * outstanding, and perform retransmissions if necessary. */
-            vARPRefreshCacheEntry( NULL, ulIPAddress, NULL );
+            vARPRefreshCacheEntry( NULL, ulIPAddress, NULL, pxNetworkBuffer->pxInterface );
 
             /* Generate an ARP for the required IP address. */
             iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->xIPAddress.ulIP_IPv4 );
@@ -382,7 +382,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
                 else
                 {
                     /* Update the age of this cache entry since a packet was received. */
-                    vARPRefreshCacheEntryAge( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress );
+                    vARPRefreshCacheEntryAge( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress, pxNetworkBuffer->pxInterface );
                 }
             }
             else
@@ -503,7 +503,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
                 if( FreeRTOS_ntohs( pxUDPPacket->xUDPHeader.usSourcePort ) == ( uint16_t ) ipDNS_PORT )
                 {
                     vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress,
-                                           pxNetworkBuffer->pxEndPoint );
+                                           pxNetworkBuffer->pxEndPoint, pxNetworkBuffer->pxInterface );
                     xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
                 }
                 else
@@ -515,7 +515,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
                     ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipLLMNR_PORT ) ) )
                 {
                     vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress,
-                                           pxNetworkBuffer->pxEndPoint );
+                                           pxNetworkBuffer->pxEndPoint, pxNetworkBuffer->pxInterface );
                     xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
                 }
                 else
@@ -534,7 +534,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
                     #endif
                     {
                         vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress,
-                                               pxNetworkBuffer->pxEndPoint );
+                                               pxNetworkBuffer->pxEndPoint, pxNetworkBuffer->pxInterface );
                     }
 
                     xReturn = ( BaseType_t ) ulDNSHandlePacket( pxNetworkBuffer );
@@ -548,7 +548,7 @@ BaseType_t xProcessReceivedUDPPacket_IPv4( NetworkBufferDescriptor_t * pxNetwork
                     ( pxUDPPacket->xUDPHeader.usSourcePort == FreeRTOS_ntohs( ipNBNS_PORT ) ) )
                 {
                     vARPRefreshCacheEntry( &( pxUDPPacket->xEthernetHeader.xSourceAddress ), pxUDPPacket->xIPHeader.ulSourceIPAddress,
-                                           pxNetworkBuffer->pxEndPoint );
+                                           pxNetworkBuffer->pxEndPoint, pxNetworkBuffer->pxInterface );
                     xReturn = ( BaseType_t ) ulNBNSHandlePacket( pxNetworkBuffer );
                 }
                 else

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -171,7 +171,7 @@ static eARPLookupResult_t prvStartLookup( NetworkBufferDescriptor_t * const pxNe
         /* Add an entry to the ARP table with a null hardware address.
          * This allows the ARP timer to know that an ARP reply is
          * outstanding, and perform retransmissions if necessary. */
-        vARPRefreshCacheEntry( NULL, ulIPAddress, NULL, pxNetworkBuffer->pxInterface );
+        vARPRefreshCacheEntry( NULL, ulIPAddress, NULL, NULL ); /* yes, this will assert */
 
         /* Generate an ARP for the required IP address. */
         iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->xIPAddress.ulIP_IPv4 );

--- a/source/FreeRTOS_UDP_IPv6.c
+++ b/source/FreeRTOS_UDP_IPv6.c
@@ -171,7 +171,7 @@ static eARPLookupResult_t prvStartLookup( NetworkBufferDescriptor_t * const pxNe
         /* Add an entry to the ARP table with a null hardware address.
          * This allows the ARP timer to know that an ARP reply is
          * outstanding, and perform retransmissions if necessary. */
-        vARPRefreshCacheEntry( NULL, ulIPAddress, NULL );
+        vARPRefreshCacheEntry( NULL, ulIPAddress, NULL, pxNetworkBuffer->pxInterface );
 
         /* Generate an ARP for the required IP address. */
         iptracePACKET_DROPPED_TO_GENERATE_ARP( pxNetworkBuffer->xIPAddress.ulIP_IPv4 );

--- a/source/include/FreeRTOS_ARP.h
+++ b/source/include/FreeRTOS_ARP.h
@@ -61,6 +61,7 @@ typedef struct xARP_CACHE_TABLE_ROW
     uint8_t ucValid;          /**< pdTRUE: xMACAddress is valid, pdFALSE: waiting for ARP reply */
     struct xNetworkEndPoint
     * pxEndPoint;             /**< The end-point on which the MAC address was last seen. */
+    struct xNetworkInterface * pxInterface; /**< interface to which this entry belongs*/
 } ARPCacheRow_t;
 
 typedef enum
@@ -84,7 +85,8 @@ typedef struct xCacheLocation
  * is found then no action will be taken.
  */
 void vARPRefreshCacheEntryAge( const MACAddress_t * pxMACAddress,
-                               const uint32_t ulIPAddress );
+                               const uint32_t ulIPAddress,
+                               struct xNetworkInterface * pxInterface );
 
 /*
  * If ulIPAddress is already in the ARP cache table then reset the age of the
@@ -97,7 +99,8 @@ void vARPRefreshCacheEntryAge( const MACAddress_t * pxMACAddress,
 
 void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
                             const uint32_t ulIPAddress,
-                            struct xNetworkEndPoint * pxEndPoint );
+                            struct xNetworkEndPoint * pxEndPoint,
+                            struct xNetworkInterface * pxInterface );
 
 #if ( ipconfigARP_USE_CLASH_DETECTION != 0 )
     /* Becomes non-zero if another device responded to a gratuitous ARP message. */
@@ -112,12 +115,13 @@ void vARPRefreshCacheEntry( const MACAddress_t * pxMACAddress,
  * In some rare cases, it might be useful to remove a ARP cache entry of a
  * known MAC address to make sure it gets refreshed.
  */
-    uint32_t ulARPRemoveCacheEntryByMac( const MACAddress_t * pxMACAddress );
+    uint32_t ulARPRemoveCacheEntryByMac( const MACAddress_t * pxMACAddress,
+                                         struct xNetworkInterface * pxInterface)
 
 #endif /* ipconfigUSE_ARP_REMOVE_ENTRY != 0 */
 
 
-BaseType_t xIsIPInARPCache( uint32_t ulAddressToLookup );
+BaseType_t xIsIPInARPCache( uint32_t ulAddressToLookup, struct xNetworkInterface * pxInterface);
 
 BaseType_t xCheckRequiresARPResolution( const NetworkBufferDescriptor_t * pxNetworkBuffer );
 
@@ -129,9 +133,10 @@ BaseType_t xCheckRequiresARPResolution( const NetworkBufferDescriptor_t * pxNetw
  * (maybe DHCP is still in process, or the addressing needs a gateway but there
  * isn't a gateway defined) then return eCantSendPacket.
  */
-eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
-                                      MACAddress_t * const pxMACAddress,
-                                      struct xNetworkEndPoint ** ppxEndPoint );
+    eARPLookupResult_t eARPGetCacheEntry( uint32_t * pulIPAddress,
+                                          MACAddress_t * const pxMACAddress,
+                                          struct xNetworkEndPoint ** ppxEndPoint,
+                                          struct xNetworkInterface * pxInterface );
 
 #if ( ipconfigUSE_ARP_REVERSED_LOOKUP != 0 )
 

--- a/source/include/FreeRTOS_IP.h
+++ b/source/include/FreeRTOS_IP.h
@@ -396,8 +396,9 @@ void FreeRTOS_UpdateMACAddress( const uint8_t ucMACAddress[ ipMAC_ADDRESS_LENGTH
 /* xARPWaitResolution checks if an IPv4 address is already known. If not
  * it may send an ARP request and wait for a reply.  This function will
  * only be called from an application. */
-BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
-                               TickType_t uxTicksToWait );
+    BaseType_t xARPWaitResolution( uint32_t ulIPAddress,
+                                   TickType_t uxTicksToWait,
+                                   struct xNetworkInterface * pxInterface );
 
 BaseType_t FreeRTOS_IsNetworkUp( void );
 


### PR DESCRIPTION
# Keep separate ARP cache per each interface

I've added a column to the ARP cache table which tags rows by interface. Threaded through interface pointers through to the ARP module. The behaviour is now

- ARP lookups will ignore cache entries that do not belong to the interface on which the lookup is happening
- When the cache is full, evict the oldest entry regardless of which interface it belongs to, and re-use that row for whichever interface needs a new ARP association

In the process I have changed the signature of much of the ARP interface, wreaking havoc on the unit tests in the process (see CI :'( ). For now I'm not going to spend time fixing them since I've tested it locally and this may not be merged anyway due to William's MAC fix.

Tested and this fixes the ARP spam for worksurfaces. Unsure if we want to merge this yet or leave it...